### PR TITLE
triage two issues

### DIFF
--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -1,0 +1,50 @@
+use serde_json::json;
+
+const OMMISSION_TEST: &str = r#"""
+/* {
+  "ISFVSN" : "2",
+  "INPUTS" : [
+    {
+      "NAME" : "inputImage",
+      "TYPE" : "image"
+    }
+  ]
+ }
+*/
+void main() {
+
+}
+"""#;
+
+#[test]
+fn does_not_emit_extra_fields() {
+    let isf = isf::parse(&OMMISSION_TEST).unwrap();
+    let isf_string = serde_json::to_string_pretty(&isf).unwrap();
+    let object: serde_json::Value = serde_json::from_str(&isf_string).unwrap();
+    let expected_object = json!({
+        "ISFVSN" : "2",
+        "INPUTS" : [{ "NAME" : "inputImage", "TYPE" : "image" }]
+    });
+    assert_eq!(object, expected_object);
+}
+
+const PANIC_TEST: &str = r#"""
+/* {
+  "INPUTS" : [
+    {
+      "NAME" : "panic_causer",
+      "TYPE" : "panic_type"
+    }
+  ]
+ }
+*/
+void main() {
+
+}
+"""#;
+
+#[test]
+fn does_not_panic_on_unknown_type() {
+    let isf_res = isf::parse(&PANIC_TEST);
+    assert!(matches!(isf_res, Err(isf::ParseError::Json { .. })));
+}

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,3 +1,4 @@
+use serde_json::json;
 // Deserialize each ISF, serialize it back to JSON, then deserialize it again and make sure both
 // deserialized instances match.
 #[test]
@@ -22,4 +23,32 @@ fn roundtrip_test_files() {
             assert_eq!(isf, isf2);
         }
     }
+}
+
+const OMMISSION_TEST: &str = r#"""
+/* {
+  "ISFVSN" : "2",
+  "INPUTS" : [
+    {
+      "NAME" : "inputImage",
+      "TYPE" : "image"
+    }
+  ]
+ }
+*/
+void main() {
+
+}
+"""#;
+
+#[test]
+fn does_not_emit_extra_fields() {
+    let isf = isf::parse(&OMMISSION_TEST).unwrap();
+    let isf_string = serde_json::to_string_pretty(&isf).unwrap();
+    let object: serde_json::Value = serde_json::from_str(&isf_string).unwrap();
+    let expected_object = json!({
+        "ISFVSN" : "2",
+        "INPUTS" : [{ "NAME" : "inputImage", "TYPE" : "image" }]
+    });
+    assert_eq!(object, expected_object);
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,4 +1,3 @@
-use serde_json::json;
 // Deserialize each ISF, serialize it back to JSON, then deserialize it again and make sure both
 // deserialized instances match.
 #[test]
@@ -23,32 +22,4 @@ fn roundtrip_test_files() {
             assert_eq!(isf, isf2);
         }
     }
-}
-
-const OMMISSION_TEST: &str = r#"""
-/* {
-  "ISFVSN" : "2",
-  "INPUTS" : [
-    {
-      "NAME" : "inputImage",
-      "TYPE" : "image"
-    }
-  ]
- }
-*/
-void main() {
-
-}
-"""#;
-
-#[test]
-fn does_not_emit_extra_fields() {
-    let isf = isf::parse(&OMMISSION_TEST).unwrap();
-    let isf_string = serde_json::to_string_pretty(&isf).unwrap();
-    let object: serde_json::Value = serde_json::from_str(&isf_string).unwrap();
-    let expected_object = json!({
-        "ISFVSN" : "2",
-        "INPUTS" : [{ "NAME" : "inputImage", "TYPE" : "image" }]
-    });
-    assert_eq!(object, expected_object);
 }


### PR DESCRIPTION
Hello, I don't know if this project is still alive but I am using it in a portable tweakable shader runtime that supports ISF and I appreciate publishing the API very much. However I've run into an issue. 

When serializing inputs the library adds all nullish and empty fields to the dict by default, this results in  output like 

```json
{
  "ISFVSN": "2.0",
  "VSN": "1.0.0",
  "DESCRIPTION": "an isf shader",
  "CATEGORIES": [],
  "INPUTS": [
    {
      "NAME": "Hello",
      "TYPE": "bool",
      "DEFAULT": false,
      "MIN": null,
      "MAX": null,
      "IDENTITY": null,
      "VALUES": [],
      "LABELS": []
    }
  ],
  "PASSES": [],
  "IMPORTED": {}
}
```
from input like 
```json
{
"INPUTS" : [ { "NAME": "Hello", "TYPE" : "bool" }]
}
```
This is will be reingested by this library just fine, but may have issues interacting with other implementations and is likely not what the user of an application that modifies ISF files is expecting.  If this was intentional please let me know. I've corrected this by adding conditionals decorators to the emitted fields.

The other Issue I've run into is that the library panics when it runs into an invalid type name. I've also included a custom error there.

